### PR TITLE
Testes para ShortestPath

### DIFF
--- a/src/teste/testGrafoController.java
+++ b/src/teste/testGrafoController.java
@@ -194,4 +194,24 @@ public class testGrafoController {
             Assert.fail();
         }
     }
+    
+    @Test
+    public void testaShortestPath1(){
+    	String expected = "[1]";
+    	try {
+            Assert.assertEquals(expected, controle.shortestPath(controle.readGrafo(grafo1), new Integer(1), new Integer(1)));
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
+    
+    @Test
+    public void testaShortestPath2(){
+        /*String expected = "[1, 2]";
+    	try {
+            Assert.assertEquals(expected, controle.shortestPath(controle.readGrafo(grafo1), new Integer(1), new Integer(2)));
+        } catch (Exception e) {
+            Assert.fail();
+        }*/
+    }
 }


### PR DESCRIPTION
Agora ShortestPath tem 1 teste pronto e 1 pendente.
testaShortestPath2() está pendente porque exige um grafo conectado
e com alguma aresta com peso negativo.