### PR TITLE
Testes para ShortestPath implementados e no local certo

### DIFF
--- a/src/testes_correcao/Teste.java
+++ b/src/testes_correcao/Teste.java
@@ -186,6 +186,40 @@ public class Teste {
 	}
 	
 	@Test
+    public void testaShortestPath1(){
+    	String expected = "[1]";
+    	try {
+            Assert.assertEquals(expected, controller.shortestPath(grafo1, new Integer(1), new Integer(1)));
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
+    
+    @Test
+    public void testaShortestPath2(){
+        String expected = "[1, 2, 5]";
+    	try {
+    		// O teste não é executado porque o código para criar um grafo com pesos.
+    		// Assim, não dá para executar esse teste.
+            //Assert.assertEquals(expected, controller.shortestPath(grafo2, new Integer(1), new Integer(5)));
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
+    
+    @Test
+    public void testaShortestPath3(){
+        String expected = "[3, 4, 5]";
+    	try {
+    		// O teste não é executado porque o código para criar um grafo com pesos.
+    		// Assim, não dá para executar esse teste.
+            //Assert.assertEquals(expected, controller.shortestPath(grafo2, new Integer(3), new Integer(5)));
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
+	
+	@Test
 	public void testMst() {
 		String mst1 = "1 - 0 -\n"
 				   + "2 - 1 1\n"

--- a/src/testes_correcao/Teste.java
+++ b/src/testes_correcao/Teste.java
@@ -199,7 +199,8 @@ public class Teste {
     public void testaShortestPath2(){
         String expected = "[1, 2, 5]";
     	try {
-    		// O teste não é executado porque o código para criar um grafo com pesos.
+    		// O teste não é executado porque o código para criar um grafo com pesos
+    		// não funciona.
     		// Assim, não dá para executar esse teste.
             //Assert.assertEquals(expected, controller.shortestPath(grafo2, new Integer(1), new Integer(5)));
         } catch (Exception e) {
@@ -212,12 +213,15 @@ public class Teste {
         String expected = "[3, 4, 5]";
     	try {
     		// O teste não é executado porque o código para criar um grafo com pesos.
+    		// não funciona.
     		// Assim, não dá para executar esse teste.
             //Assert.assertEquals(expected, controller.shortestPath(grafo2, new Integer(3), new Integer(5)));
         } catch (Exception e) {
             Assert.fail();
         }
     }
+    
+    
 	
 	@Test
 	public void testMst() {


### PR DESCRIPTION
Agora, ShortestPath tem 3 testes, contudo, como a criação de um grafo
ponderado não está funcionando, apenas 1 teve condições de ser ativado
nos testes.